### PR TITLE
html asset source() needs to be written, not the Object

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ HtmlWebpackHarddiskPlugin.prototype.writeAssetToDisk = function (compilation, ht
       return callback(err);
     }
     // Write to disk
-    fs.writeFile(fullPath, compilation.assets[webpackHtmlFilename], function (err) {
+    fs.writeFile(fullPath, compilation.assets[webpackHtmlFilename].source(), function (err) {
       if (err) {
         return callback(err);
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "prepublish": "npm run test",
     "pretest": "semistandard",
-    "test": "jasmine"
+    "test": "jasmine",
+    "debug": "node-debug jasmine"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jasmine": "^2.4.1",
     "memory-fs": "^0.3.0",
     "rimraf": "^2.5.2",
+    "script-ext-html-webpack-plugin": "^1.2.1",
     "semistandard": "^7.0.5",
     "webpack": "^1.13.0"
   },

--- a/spec/fixtures/entry.js
+++ b/spec/fixtures/entry.js
@@ -1,1 +1,2 @@
+require('./script.js');
 console.log('hello world');

--- a/spec/fixtures/entry_with_script.js
+++ b/spec/fixtures/entry_with_script.js
@@ -1,1 +1,2 @@
+require('./script.js');
 console.log('hello world');

--- a/spec/fixtures/script.js
+++ b/spec/fixtures/script.js
@@ -1,0 +1,1 @@
+module.exports = 'a script';

--- a/spec/fixtures/script.js
+++ b/spec/fixtures/script.js
@@ -1,1 +1,1 @@
-module.exports = 'a script';
+module.exports = 'an inlined script';

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -6,6 +6,7 @@ var webpack = require('webpack');
 var rm_rf = require('rimraf');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var HtmlWebpackHarddiskPlugin = require('../');
+var ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 
 var OUTPUT_DIR = path.join(__dirname, '../dist');
 
@@ -81,6 +82,30 @@ describe('HtmlWebpackHarddiskPlugin', function () {
       expect(fs.existsSync(demoHtmlFile)).toBe(true);
       var skipHtmlFile = path.resolve(__dirname, '../dist/skip.html');
       expect(fs.existsSync(skipHtmlFile)).toBe(false);
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
+
+  it('works alongside other plugins on the same event', function (done) {
+    var compiler = webpack({
+      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      output: {
+        path: OUTPUT_DIR
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          alwaysWriteToDisk: true
+        }),
+        new HtmlWebpackHarddiskPlugin(),
+        new ScriptExtHtmlWebpackPlugin({
+          inline: [/\.js?/]
+        })
+      ]
+    }, function (err) {
+      expect(err).toBeFalsy();
+      var htmlFile = path.resolve(__dirname, '../dist/index.html');
+      expect(fs.existsSync(htmlFile)).toBe(true);
       done();
     });
     compiler.outputFileSystem = new MemoryFileSystem();

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -57,7 +57,7 @@ describe('HtmlWebpackHarddiskPlugin', function () {
 
   it('generates multiple files even if webpack is set to memory-fs', function (done) {
     var compiler = webpack({
-      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      entry: path.join(__dirname, 'fixtures', 'entry_with_script.js'),
       output: {
         path: OUTPUT_DIR
       },
@@ -89,7 +89,7 @@ describe('HtmlWebpackHarddiskPlugin', function () {
 
   it('works alongside other plugins on the same event', function (done) {
     var compiler = webpack({
-      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      entry: path.join(__dirname, 'fixtures', 'entry_with_script.js'),
       output: {
         path: OUTPUT_DIR
       },
@@ -106,6 +106,8 @@ describe('HtmlWebpackHarddiskPlugin', function () {
       expect(err).toBeFalsy();
       var htmlFile = path.resolve(__dirname, '../dist/index.html');
       expect(fs.existsSync(htmlFile)).toBe(true);
+      var htmlContent = fs.readFileSync(htmlFile).toString();
+      expect(htmlContent).toContain('an inlined script');
       done();
     });
     compiler.outputFileSystem = new MemoryFileSystem();


### PR DESCRIPTION
The crucial change is the one-liner in index.js.
All the other changes are actually to create an additional test to ensure the plugin works with other plugins on the same 'emit' event.  (It does).