### PR TITLE
Adding require() code to README for explictness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ $ npm install --save-dev html-webpack-harddisk-plugin
 
 Basic Usage
 -----------
+Require the plugin in your webpack config:
+
+```javascript
+var HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
+```
+
 Add the plugin to your webpack config as follows:
 
 ```javascript


### PR DESCRIPTION
Just to save developers from having to type out the whole line, they can copy and paste, and not accidentally forget it the first time (like I did)