### PR TITLE
Support explicit output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ plugins: [
   new HtmlWebpackHarddiskPlugin()
 ]  
 ```
+
+If you need to set the output path explicitly (for example when using with webpack-dev-server middleware) then pass in the `outputPath` option:
+
+```
+new HtmlWebpackHarddiskPlugin({
+  outputPath: path.resolve(__dirname, 'views')
+})
+```

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict';
-var assert = require('assert');
 var mkdirp = require('mkdirp');
 var fs = require('fs');
 var path = require('path');
 
 function HtmlWebpackHarddiskPlugin (options) {
-  assert.equal(options, undefined, 'The HtmlWebpackHarddiskPlugin does not accept any options');
+  options = options || {};
+  this.outputPath = options.outputPath;
 }
 
 HtmlWebpackHarddiskPlugin.prototype.apply = function (compiler) {
@@ -27,7 +27,7 @@ HtmlWebpackHarddiskPlugin.prototype.writeAssetToDisk = function (compilation, ht
     return callback(null);
   }
   // Prepare the folder
-  var fullPath = path.resolve(compilation.compiler.outputPath, webpackHtmlFilename);
+  var fullPath = path.resolve(this.outputPath || compilation.compiler.outputPath, webpackHtmlFilename);
   var directory = path.dirname(fullPath);
   mkdirp(directory, function (err) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-webpack-harddisk-plugin",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Write html files to hard disk even when using the webpack dev server or middleware",
   "main": "index.js",
   "files": [

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -85,4 +85,38 @@ describe('HtmlWebpackHarddiskPlugin', function () {
     });
     compiler.outputFileSystem = new MemoryFileSystem();
   });
+
+  it('writes to specific outputPath if specified in options', function (done) {
+    var compiler = webpack({
+      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      output: {
+        path: OUTPUT_DIR
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          alwaysWriteToDisk: true
+        }),
+        new HtmlWebpackPlugin({
+          filename: 'demo.html',
+          alwaysWriteToDisk: true
+        }),
+        new HtmlWebpackPlugin({
+          filename: 'skip.html'
+        }),
+        new HtmlWebpackHarddiskPlugin({
+          outputPath: path.resolve(OUTPUT_DIR, 'foo')
+        })
+      ]
+    }, function (err) {
+      expect(err).toBeFalsy();
+      var htmlFile = path.resolve(__dirname, '../dist/foo/index.html');
+      expect(fs.existsSync(htmlFile)).toBe(true);
+      var demoHtmlFile = path.resolve(__dirname, '../dist/foo/demo.html');
+      expect(fs.existsSync(demoHtmlFile)).toBe(true);
+      var skipHtmlFile = path.resolve(__dirname, '../dist/foo/skip.html');
+      expect(fs.existsSync(skipHtmlFile)).toBe(false);
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
 });


### PR DESCRIPTION
I did this for my use case with `webpack-dev-server` middleware, but it should also address https://github.com/jantimon/html-webpack-harddisk-plugin/issues/3.  Published to npm as `@captemulation/html-webpack-harddisk-plugin@0.1.0`