### PR TITLE
Add index.d.ts to packaje.json

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,20 @@
-import { Plugin } from 'webpack';
+// Type definitions for html-webpack-harddisk-plugin 0.4.0
+// Project: https://github.com/alexindigo/webpack-chunk-hash
+// Definitions by: Cristian Lorenzo <https://github.com/dogmatico>
 
-interface HtmlWebpackHarddiskPluginOptions {
+import { Plugin } from "webpack";
+
+declare class HtmlWebpackHarddiskPlugin extends Plugin {
+  constructor(options?: HtmlWebpackHarddiskPlugin.Options);
+}
+
+declare namespace HtmlWebpackHarddiskPlugin {
+  interface Options {
   /**
    * Path where to save compiled assets
    */
-  outputPath?: string;
+    outputPath?: string;
+  }
 }
 
-interface HtmlWebpackHarddiskPlugin extends Plugin {
-  new (options?: HtmlWebpackHarddiskPluginOptions): HtmlWebpackHarddiskPlugin;
-}
-
-declare const htmlWebpackHarddiskPlugin: HtmlWebpackHarddiskPlugin
-export = htmlWebpackHarddiskPlugin
+export = HtmlWebpackHarddiskPlugin;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Write html files to hard disk even when using the webpack dev server or middleware",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "prepublish": "npm run test",


### PR DESCRIPTION
We need to add index.d.ts to files array. Otherwise, it isn't copied to node_modules folder. Also, did a refactor of the typing to allow exports of types.