### PR TITLE
Update peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "webpack": "^4.20.2"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^2.0.0 || ^3.0.0",
+    "html-webpack-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
We use this plugin with `html-webpack-plugin` version `4.0.0-beta.5` and nothing goes wrong. PR #17 was also done to ensure that it works on v4 too.

Not bumping this peer dependency gives the warning
```has incorrect peer dependency "html-webpack-plugin@^2.0.0 || ^3.0.0"``` which isn't a big deal but fixing this is an easy change so might as well put out the PR for it.

My only concern is I don't know why you downgraded the dev dependency in this commit: 792d555f280c06f51023c235ab23a065e0116660