### PR TITLE
Webpack 5 does not export `Plugin` interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'webpack';
+import { WebpackPluginInstance } from 'webpack';
 
 interface HtmlWebpackHarddiskPluginOptions {
   /**
@@ -7,7 +7,7 @@ interface HtmlWebpackHarddiskPluginOptions {
   outputPath?: string;
 }
 
-interface HtmlWebpackHarddiskPlugin extends Plugin {
+interface HtmlWebpackHarddiskPlugin extends WebpackPluginInstance {
   new (options?: HtmlWebpackHarddiskPluginOptions): HtmlWebpackHarddiskPlugin;
 }
 


### PR DESCRIPTION
The `Plugin` interface does not exist in the Webpack 5 `index.d.ts` definitions. Instead, you must use `WebpackPluginInstance`. Tested locally and Typescript ran successfully.

Note: this is a breaking change for any Webpack 4 + Typescript users and below.